### PR TITLE
add a codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-backend @ValentinTrinque
-frontend  @mattrussel36 @dexturr
+backend @vegaprotocol/core
+frontend @vegaprotocol/frontend
 
-* @ValentinTrinque
+* @vegaprotocol/core @vegaprotocol/frontend


### PR DESCRIPTION
Add codeowners so people are automatically added for pull request.

Added @ValentinTrinque for the backend stuff
Added @mattrussell36  and myself for frontend
Added @ValentinTrinque as default as the root files are mainly wails-centric

None of this is set in stone just a first pass, please let me know how you would prefer this if you have strong feelings/opinions.

Should @Ditmir-Vega and @jtsang586 need to be added to automation as well?