### PR TITLE
add scrollbar styles, better signing UX

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -139,3 +139,19 @@ https://create-react-app.dev/docs/adding-images-fonts-and-files/
 .vega-border-image {
   border-image: url('./images/vega-bg.png') 15%;
 }
+
+::-webkit-scrollbar {
+  width: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--light-gray5);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--gray1);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--dark-gray5);
+}

--- a/frontend/src/routes/wallet/sign.tsx
+++ b/frontend/src/routes/wallet/sign.tsx
@@ -7,7 +7,9 @@ import { CopyWithTooltip } from '../../components/copy-with-tooltip'
 import { FormGroup } from '../../components/form-group'
 import { Header } from '../../components/header'
 import { requestPassphrase } from '../../components/passphrase-modal'
+import { AppToaster } from '../../components/toaster'
 import { Colors } from '../../config/colors'
+import { Intent } from '../../config/intent'
 import { Service } from '../../service'
 
 interface FormFields {
@@ -29,8 +31,12 @@ const useSign = (pubKey: string, wallet: string) => {
         })
         // @ts-ignore
         setSignedData(resp.hexSignature)
-      } catch (e) {
-        console.log(e)
+        AppToaster.show({
+          message: `Message signed successfully`,
+          intent: Intent.SUCCESS
+        })
+      } catch (err) {
+        AppToaster.show({ message: `${err}`, intent: Intent.DANGER })
       }
     },
     [pubKey, wallet]

--- a/frontend/src/routes/wallet/sign.tsx
+++ b/frontend/src/routes/wallet/sign.tsx
@@ -37,6 +37,7 @@ const useSign = (pubKey: string, wallet: string) => {
   )
   return {
     signedData,
+    setSignedData,
     sign
   }
 }
@@ -54,23 +55,12 @@ export const Sign = ({
     formState: { errors }
   } = useForm<FormFields>()
 
-  const { sign, signedData } = useSign(pubKey, wallet)
+  const { sign, signedData, setSignedData } = useSign(pubKey, wallet)
   return (
     <>
       <Header style={{ marginTop: 32, fontSize: 18 }}>Sign</Header>
-      <form onSubmit={handleSubmit(sign)}>
-        <FormGroup
-          label='Message'
-          labelFor='message'
-          helperText={errors.message?.message}
-        >
-          <textarea
-            {...register('message', { required: 'Required' })}
-          ></textarea>
-        </FormGroup>
-        <Button type='submit'>Sign</Button>
-      </form>
-      {signedData && (
+
+      {signedData ? (
         <>
           <h4>Signed message:</h4>
           <CopyWithTooltip text={signedData}>
@@ -84,7 +74,23 @@ export const Sign = ({
               {signedData}
             </ButtonUnstyled>
           </CopyWithTooltip>
+          <Button style={{ marginTop: 12 }} onClick={() => setSignedData('')}>
+            Sign more
+          </Button>
         </>
+      ) : (
+        <form onSubmit={handleSubmit(sign)}>
+          <FormGroup
+            label='Message'
+            labelFor='message'
+            helperText={errors.message?.message}
+          >
+            <textarea
+              {...register('message', { required: 'Required' })}
+            ></textarea>
+          </FormGroup>
+          <Button type='submit'>Sign</Button>
+        </form>
       )}
     </>
   )


### PR DESCRIPTION
Closes #163
Closes #167 

* Scroll bars now show, I just took a random run at this if anyone has an opinion on styling please let me know
<img width="462" alt="Screenshot 2022-02-23 at 13 50 04" src="https://user-images.githubusercontent.com/26136207/155332354-ee952078-c7d4-4693-b88d-5b6138a943bf.png">
 * Now when a message is signed the form is hidden and users must press "Sign more" to sign a different message. I believe this is the simplest way to address the UX concerns in #163.