### PR TITLE
ci: stop adding UI issues on core project board

### DIFF
--- a/.github/workflows/add-issues-to-boards.yml
+++ b/.github/workflows/add-issues-to-boards.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add issue to Core board
+        if: contains(github.event.issue.labels.*.name, 'ui') != true
         env:
           GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
           PROJECT_ID: ${{ secrets.CORE_PROJECT_ID }}


### PR DESCRIPTION
Stop issues with the `ui` label from being added to the core board

closes #197 .