### PR TITLE
chore: remove Partial<Config> from UpdateAppConfig because that is no…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [84](https://github.com/vegaprotocol/vegawallet-desktop/pull/84) - Support defining a default network to connect to.
 - [191](https://github.com/vegaprotocol/vegawallet-desktop/pull/191) - Add meaningful colors to service and proxies state indicator.
 - [190](https://github.com/vegaprotocol/vegawallet-desktop/pull/190) - Add transaction review
+- [249](https://github.com/vegaprotocol/vegawallet-desktop/pull/249) - Remove partial from `Config` since it is not
 
 ## 0.1.1
 

--- a/frontend/src/contexts/global/global-actions.ts
+++ b/frontend/src/contexts/global/global-actions.ts
@@ -10,7 +10,7 @@ import type {
   StartServiceRequest,
   DescribeKeyResponse
 } from '../../wailsjs/go/models'
-import { GenerateKeyRequest } from '../../wailsjs/go/models'
+import { Config, GenerateKeyRequest } from '../../wailsjs/go/models'
 import type { GlobalDispatch, GlobalState } from './global-context'
 import { ProxyName } from './global-context'
 import type { GlobalAction } from './global-reducer'
@@ -252,10 +252,12 @@ export function changeNetworkAction(network: string) {
       await stopProxies()
       dispatch({ type: 'STOP_ALL_PROXIES' })
 
-      await Service.UpdateAppConfig({
-        ...state.config,
-        defaultNetwork: network
-      })
+      await Service.UpdateAppConfig(
+        new Config({
+          ...state.config,
+          defaultNetwork: network
+        })
+      )
 
       const config = await Service.GetNetworkConfig(network)
 

--- a/frontend/src/contexts/global/global-context.ts
+++ b/frontend/src/contexts/global/global-context.ts
@@ -47,7 +47,7 @@ export interface NetworkPreset {
 export interface GlobalState {
   status: AppStatus
   version: string
-  config: Config | null
+  config: Config
   onboarding: {
     wallets: string[]
     networks: string[]

--- a/frontend/src/types/handler.ts
+++ b/frontend/src/types/handler.ts
@@ -66,7 +66,7 @@ export interface Handler {
   StopService(): Promise<boolean>
   TaintKey(arg1: TaintKeyRequest): Promise<void>
   UntaintKey(arg1: UntaintKeyRequest): Promise<void>
-  UpdateAppConfig(arg1: Partial<Config>): Promise<void>
+  UpdateAppConfig(arg1: Config): Promise<void>
   SearchForExistingConfiguration(): Promise<SearchForExistingConfigurationResponse>
   StartConsole(arg1: StartServiceRequest): Promise<boolean>
   StartTokenDApp(arg1: StartServiceRequest): Promise<boolean>


### PR DESCRIPTION
closes #249 

The story here is that `Partial<Config>` it isn't in any wails generated code and the backend never made the promise that it would allow that. I don't know how that line got there? The workflow for config updates in the wallet is like "Get -> ammend -> Set" and so it doesn't support by-design partial updated.

So I've just removed the `Partial` and fixed all the squigglies that appeared in my editor.