### PR TITLE
fix: can't move window while confirmation popup is visible (263)

### DIFF
--- a/frontend/src/components/dialog/dialog.tsx
+++ b/frontend/src/components/dialog/dialog.tsx
@@ -35,6 +35,7 @@ export function Dialog({ open, children, onChange, size = 'sm' }: DialogProps) {
                       background: 'rgba(54, 54, 54 ,0.8)',
                       opacity: styles.opacity
                     }}
+                    data-wails-drag
                   />
                 </DialogPrimitives.Overlay>
                 <DialogPrimitives.Content forceMount={true} asChild={true}>


### PR DESCRIPTION
Closes #263

The issue occurred only when a title bar area was occupied by a `div` and because we use *inset* title bar the dialog's overlay blocked it from being draggable.

I've added `[data-wails-drag]` to the dialog's overlay which makes it draggable.