### PR TITLE
Fix/262: Network switch warning

### DIFF
--- a/frontend/src/components/chrome/drawer-network.tsx
+++ b/frontend/src/components/chrome/drawer-network.tsx
@@ -1,11 +1,9 @@
 import { DrawerPanel, useGlobal } from '../../contexts/global/global-context'
 import { Button } from '../button'
 import { ButtonUnstyled } from '../button-unstyled'
-import { DropdownItem, DropdownMenu } from '../dropdown-menu'
-import { DropdownArrow } from '../icons/dropdown-arrow'
 import { NetworkInfo } from '../network-info'
 import { Title } from '../title'
-import type {} from './drawer-content'
+import { NetworkSwitcher } from '../network-switcher'
 
 interface DrawerNetworkProps {
   setView: (panel: DrawerPanel) => void
@@ -13,10 +11,9 @@ interface DrawerNetworkProps {
 
 export function DrawerNetwork({ setView }: DrawerNetworkProps) {
   const {
-    state: { network, networks },
-    actions,
-    dispatch
+    state: { networks },
   } = useGlobal()
+
   return (
     <>
       <Title style={{ marginTop: 0 }}>Network</Title>
@@ -29,47 +26,7 @@ export function DrawerNetwork({ setView }: DrawerNetworkProps) {
             marginBottom: 20
           }}
         >
-          <DropdownMenu
-            trigger={
-              <Button
-                data-testid='network-select'
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  gap: 5,
-                  minWidth: 75
-                }}
-              >
-                <span>{network}</span>
-                <DropdownArrow
-                  style={{ width: 13, height: 13, marginLeft: 10 }}
-                />
-              </Button>
-            }
-            content={
-              <div>
-                {networks.map(network => (
-                  <DropdownItem key={network}>
-                    <ButtonUnstyled
-                      data-testid={`select-${network}`}
-                      style={{
-                        width: '100%',
-                        padding: '10px 15px',
-                        lineHeight: 1,
-                        textAlign: 'left'
-                      }}
-                      onClick={() => {
-                        dispatch(actions.changeNetworkAction(network))
-                      }}
-                    >
-                      {network}
-                    </ButtonUnstyled>
-                  </DropdownItem>
-                ))}
-              </div>
-            }
-          />
+          <NetworkSwitcher />
           <ButtonUnstyled
             data-testid='manage-networks'
             onClick={() => setView(DrawerPanel.Manage)}

--- a/frontend/src/components/chrome/drawer-network.tsx
+++ b/frontend/src/components/chrome/drawer-network.tsx
@@ -2,8 +2,8 @@ import { DrawerPanel, useGlobal } from '../../contexts/global/global-context'
 import { Button } from '../button'
 import { ButtonUnstyled } from '../button-unstyled'
 import { NetworkInfo } from '../network-info'
-import { Title } from '../title'
 import { NetworkSwitcher } from '../network-switcher'
+import { Title } from '../title'
 
 interface DrawerNetworkProps {
   setView: (panel: DrawerPanel) => void
@@ -11,7 +11,7 @@ interface DrawerNetworkProps {
 
 export function DrawerNetwork({ setView }: DrawerNetworkProps) {
   const {
-    state: { networks },
+    state: { networks }
   } = useGlobal()
 
   return (

--- a/frontend/src/components/connection-list/connection-item.tsx
+++ b/frontend/src/components/connection-list/connection-item.tsx
@@ -40,7 +40,9 @@ export const ConnectionItem = ({
         >
           <StatusCircle
             blinking={connection.active}
-            background={connection.active ? Colors.VEGA_GREEN : Colors.VEGA_ORANGE}
+            background={
+              connection.active ? Colors.VEGA_GREEN : Colors.VEGA_ORANGE
+            }
           />
           {connection.hostname}
         </pre>

--- a/frontend/src/components/connection-list/connection-item.tsx
+++ b/frontend/src/components/connection-list/connection-item.tsx
@@ -40,7 +40,7 @@ export const ConnectionItem = ({
         >
           <StatusCircle
             blinking={connection.active}
-            background={connection.active ? Colors.VEGA_GREEN : Colors.VEGA_RED}
+            background={connection.active ? Colors.VEGA_GREEN : Colors.VEGA_ORANGE}
           />
           {connection.hostname}
         </pre>

--- a/frontend/src/components/dialog/dialog.tsx
+++ b/frontend/src/components/dialog/dialog.tsx
@@ -1,12 +1,12 @@
 import * as DialogPrimitives from '@radix-ui/react-dialog'
-import * as React from 'react'
+import type { ReactNode } from 'react'
 import { animated, config, useTransition } from 'react-spring'
 
 import { Title } from '../title'
 
 interface DialogProps {
   open: boolean
-  title?: string
+  title?: ReactNode
   children: React.ReactNode
   size?: 'sm' | 'lg'
   onChange?: (open: boolean) => void

--- a/frontend/src/components/network-switcher/connections-warning-dialog.tsx
+++ b/frontend/src/components/network-switcher/connections-warning-dialog.tsx
@@ -6,10 +6,12 @@ import { Warning } from '../icons/warning'
 
 const WarningPrompt = ({ wallets }: { wallets: string[] }) => {
   if (wallets.length > 1) {
-    ;<p>
-      You have active connections in the following wallets:{' '}
-      <code>{wallets.join(', ')}</code>.
-    </p>
+    return (
+      <p>
+        You have active connections in the following wallets:{' '}
+        <code>{wallets.join(', ')}</code>.
+      </p>
+    )
   }
   return (
     <p>

--- a/frontend/src/components/network-switcher/connections-warning-dialog.tsx
+++ b/frontend/src/components/network-switcher/connections-warning-dialog.tsx
@@ -1,0 +1,52 @@
+import { Dialog } from '../dialog'
+import { Button } from '../button'
+import { ButtonUnstyled } from '../button-unstyled'
+import { ButtonGroup } from '../button-group'
+import { Warning } from '../icons/warning'
+
+const WarningPrompt = ({ wallets }: { wallets: string[] }) => {
+  if (wallets.length > 1) {
+    <p>You have active connections in the following wallets: <code>{wallets.join(', ')}</code>.</p>
+  }
+  return <p>You have active connections in your <code>{wallets[0]}</code> wallet.</p>
+}
+
+type NetworkSwitchDialogProps = {
+  activeConnections: string[]
+  isOpen: boolean
+  setOpen: (isOpen: boolean) => void
+  onConfirm: () => void
+}
+
+export const ConnectionsWarningDialog = ({
+  activeConnections,
+  isOpen,
+  setOpen,
+  onConfirm
+}: NetworkSwitchDialogProps) => {
+  return (
+    <Dialog
+      open={isOpen && activeConnections.length > 0}
+      title={(
+        <>
+          <Warning style={{ width: 20, marginRight: 12 }} />
+          Warning
+        </>
+      )}
+      onChange={setOpen}
+    >
+      <div style={{ padding: 20 }}>
+        <WarningPrompt wallets={activeConnections} />
+        <p>Switching networks will result in losing these connections, and having to reconnect the dApps to your wallets.</p>
+      </div>
+      <ButtonGroup inline style={{ padding: 20 }}>
+        <Button onClick={onConfirm}>
+          Switch
+        </Button>
+        <ButtonUnstyled onClick={() => setOpen(false)}>
+          Cancel
+        </ButtonUnstyled>
+      </ButtonGroup>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/network-switcher/connections-warning-dialog.tsx
+++ b/frontend/src/components/network-switcher/connections-warning-dialog.tsx
@@ -1,14 +1,21 @@
-import { Dialog } from '../dialog'
 import { Button } from '../button'
-import { ButtonUnstyled } from '../button-unstyled'
 import { ButtonGroup } from '../button-group'
+import { ButtonUnstyled } from '../button-unstyled'
+import { Dialog } from '../dialog'
 import { Warning } from '../icons/warning'
 
 const WarningPrompt = ({ wallets }: { wallets: string[] }) => {
   if (wallets.length > 1) {
-    <p>You have active connections in the following wallets: <code>{wallets.join(', ')}</code>.</p>
+    ;<p>
+      You have active connections in the following wallets:{' '}
+      <code>{wallets.join(', ')}</code>.
+    </p>
   }
-  return <p>You have active connections in your <code>{wallets[0]}</code> wallet.</p>
+  return (
+    <p>
+      You have active connections in your <code>{wallets[0]}</code> wallet.
+    </p>
+  )
 }
 
 type NetworkSwitchDialogProps = {
@@ -27,25 +34,24 @@ export const ConnectionsWarningDialog = ({
   return (
     <Dialog
       open={isOpen && activeConnections.length > 0}
-      title={(
+      title={
         <>
           <Warning style={{ width: 20, marginRight: 12 }} />
           Warning
         </>
-      )}
+      }
       onChange={setOpen}
     >
       <div style={{ padding: 20 }}>
         <WarningPrompt wallets={activeConnections} />
-        <p>Switching networks will result in losing these connections, and having to reconnect the dApps to your wallets.</p>
+        <p>
+          Switching networks will result in losing these connections, and having
+          to reconnect the dApps to your wallets.
+        </p>
       </div>
       <ButtonGroup inline style={{ padding: 20 }}>
-        <Button onClick={onConfirm}>
-          Switch
-        </Button>
-        <ButtonUnstyled onClick={() => setOpen(false)}>
-          Cancel
-        </ButtonUnstyled>
+        <Button onClick={onConfirm}>Switch</Button>
+        <ButtonUnstyled onClick={() => setOpen(false)}>Cancel</ButtonUnstyled>
       </ButtonGroup>
     </Dialog>
   )

--- a/frontend/src/components/network-switcher/index.tsx
+++ b/frontend/src/components/network-switcher/index.tsx
@@ -1,0 +1,1 @@
+export * from './network-switcher'

--- a/frontend/src/components/network-switcher/network-switcher.tsx
+++ b/frontend/src/components/network-switcher/network-switcher.tsx
@@ -1,12 +1,13 @@
-import { useState, useMemo, useCallback } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+
+import { Colors } from '../../config/colors'
+import type { Wallet } from '../../contexts/global/global-context'
+import { useGlobal } from '../../contexts/global/global-context'
 import { Button } from '../button'
 import { ButtonUnstyled } from '../button-unstyled'
 import { DropdownItem, DropdownMenu } from '../dropdown-menu'
 import { DropdownArrow } from '../icons/dropdown-arrow'
 import { ConnectionsWarningDialog } from './connections-warning-dialog'
-import { Colors } from '../../config/colors'
-import { useGlobal } from '../../contexts/global/global-context'
-import type { Wallet } from '../../contexts/global/global-context'
 
 const findActiveConnections = (wallets: Record<string, Wallet>) => {
   return Object.keys(wallets).reduce<string[]>((acc, walletName) => {
@@ -20,27 +21,27 @@ const findActiveConnections = (wallets: Record<string, Wallet>) => {
 }
 
 export const NetworkSwitcher = () => {
-  const {
-    state,
-    actions,
-    dispatch
-  } = useGlobal()
+  const { state, actions, dispatch } = useGlobal()
   const [hasConnectionWarning, setConnectionWarning] = useState(false)
   const [selectedNetwork, setSelectedNetwork] = useState(state.network)
-  const activeConnections = useMemo(() => (
-    findActiveConnections(state.wallets)
-  ), [state.wallets])
+  const activeConnections = useMemo(
+    () => findActiveConnections(state.wallets),
+    [state.wallets]
+  )
 
   console.log(activeConnections)
 
-  const handleNetworkChange = useCallback((network: string) => {
-    if (activeConnections.length) {
-      setSelectedNetwork(network)
-      setConnectionWarning(true)
-      return
-    }
-    dispatch(actions.changeNetworkAction(network))
-  }, [dispatch, actions, activeConnections])
+  const handleNetworkChange = useCallback(
+    (network: string) => {
+      if (activeConnections.length) {
+        setSelectedNetwork(network)
+        setConnectionWarning(true)
+        return
+      }
+      dispatch(actions.changeNetworkAction(network))
+    },
+    [dispatch, actions, activeConnections]
+  )
 
   const handleConfirm = useCallback(() => {
     if (selectedNetwork) {
@@ -63,9 +64,7 @@ export const NetworkSwitcher = () => {
             }}
           >
             <span>{state.network}</span>
-            <DropdownArrow
-              style={{ width: 13, height: 13, marginLeft: 10 }}
-            />
+            <DropdownArrow style={{ width: 13, height: 13, marginLeft: 10 }} />
           </Button>
         }
         content={
@@ -79,7 +78,10 @@ export const NetworkSwitcher = () => {
                     padding: '10px 15px',
                     lineHeight: 1,
                     textAlign: 'left',
-                    color: network === selectedNetwork ? Colors.TEXT_COLOR_DEEMPHASISE : Colors.WHITE,
+                    color:
+                      network === selectedNetwork
+                        ? Colors.TEXT_COLOR_DEEMPHASISE
+                        : Colors.WHITE
                   }}
                   onClick={() => {
                     handleNetworkChange(network)

--- a/frontend/src/components/network-switcher/network-switcher.tsx
+++ b/frontend/src/components/network-switcher/network-switcher.tsx
@@ -29,8 +29,6 @@ export const NetworkSwitcher = () => {
     [state.wallets]
   )
 
-  console.log(activeConnections)
-
   const handleNetworkChange = useCallback(
     (network: string) => {
       if (activeConnections.length) {

--- a/frontend/src/components/network-switcher/network-switcher.tsx
+++ b/frontend/src/components/network-switcher/network-switcher.tsx
@@ -1,0 +1,103 @@
+import { useState, useMemo, useCallback } from 'react'
+import { Button } from '../button'
+import { ButtonUnstyled } from '../button-unstyled'
+import { DropdownItem, DropdownMenu } from '../dropdown-menu'
+import { DropdownArrow } from '../icons/dropdown-arrow'
+import { ConnectionsWarningDialog } from './connections-warning-dialog'
+import { Colors } from '../../config/colors'
+import { useGlobal } from '../../contexts/global/global-context'
+import type { Wallet } from '../../contexts/global/global-context'
+
+const findActiveConnections = (wallets: Record<string, Wallet>) => {
+  return Object.keys(wallets).reduce<string[]>((acc, walletName) => {
+    const connections = wallets[walletName].connections || {}
+    const hosts = Object.keys(connections)
+    if (hosts.find(host => connections[host].active)) {
+      acc.push(walletName)
+    }
+    return acc
+  }, [])
+}
+
+export const NetworkSwitcher = () => {
+  const {
+    state,
+    actions,
+    dispatch
+  } = useGlobal()
+  const [hasConnectionWarning, setConnectionWarning] = useState(false)
+  const [selectedNetwork, setSelectedNetwork] = useState(state.network)
+  const activeConnections = useMemo(() => (
+    findActiveConnections(state.wallets)
+  ), [state.wallets])
+
+  console.log(activeConnections)
+
+  const handleNetworkChange = useCallback((network: string) => {
+    if (activeConnections.length) {
+      setSelectedNetwork(network)
+      setConnectionWarning(true)
+      return
+    }
+    dispatch(actions.changeNetworkAction(network))
+  }, [dispatch, actions, activeConnections])
+
+  const handleConfirm = useCallback(() => {
+    if (selectedNetwork) {
+      dispatch(actions.changeNetworkAction(selectedNetwork))
+    }
+  }, [dispatch, actions, selectedNetwork])
+
+  return (
+    <>
+      <DropdownMenu
+        trigger={
+          <Button
+            data-testid='network-select'
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              gap: 5,
+              minWidth: 75
+            }}
+          >
+            <span>{state.network}</span>
+            <DropdownArrow
+              style={{ width: 13, height: 13, marginLeft: 10 }}
+            />
+          </Button>
+        }
+        content={
+          <div>
+            {state.networks.map(network => (
+              <DropdownItem key={network}>
+                <ButtonUnstyled
+                  data-testid={`select-${network}`}
+                  style={{
+                    width: '100%',
+                    padding: '10px 15px',
+                    lineHeight: 1,
+                    textAlign: 'left',
+                    color: network === selectedNetwork ? Colors.TEXT_COLOR_DEEMPHASISE : Colors.WHITE,
+                  }}
+                  onClick={() => {
+                    handleNetworkChange(network)
+                  }}
+                >
+                  {network}
+                </ButtonUnstyled>
+              </DropdownItem>
+            ))}
+          </div>
+        }
+      />
+      <ConnectionsWarningDialog
+        activeConnections={activeConnections}
+        isOpen={hasConnectionWarning}
+        setOpen={setConnectionWarning}
+        onConfirm={handleConfirm}
+      />
+    </>
+  )
+}

--- a/frontend/src/contexts/global/global-reducer.ts
+++ b/frontend/src/contexts/global/global-reducer.ts
@@ -79,6 +79,7 @@ export type GlobalAction =
         networks: string[]
       }
     }
+  // Wallet
   | {
       type: 'ADD_WALLET'
       wallet: string
@@ -135,6 +136,7 @@ export type GlobalAction =
       type: 'DEACTIVATE_WALLET'
       wallet: string
     }
+  // UI
   | {
       type: 'SET_DRAWER'
       state: DrawerState

--- a/frontend/src/hooks/use-open-wallet.tsx
+++ b/frontend/src/hooks/use-open-wallet.tsx
@@ -52,7 +52,7 @@ export const useOpenWallet = () => {
             })
             return {
               hostname,
-              active: true,
+              active: false,
               permissions: result.permissions
             }
           })

--- a/frontend/src/routes/home/home.tsx
+++ b/frontend/src/routes/home/home.tsx
@@ -53,10 +53,7 @@ export const Home = () => {
   const actionWrapperStyles = wallets.length ? actionStyles : undefined
 
   return (
-    <div
-      data-testid='wallet-home'
-      style={{ padding: 20 }}
-    >
+    <div data-testid='wallet-home' style={{ padding: 20 }}>
       <Title
         style={{
           margin: '0 0 30px 0',

--- a/frontend/src/routes/home/home.tsx
+++ b/frontend/src/routes/home/home.tsx
@@ -55,8 +55,7 @@ export const Home = () => {
   return (
     <div
       data-testid='wallet-home'
-      className='vega-border-image'
-      style={{ borderTop: '3px solid', padding: 20 }}
+      style={{ padding: 20 }}
     >
       <Title
         style={{


### PR DESCRIPTION
Closes #262 

Displays a warning when there are active connections in any of the wallets, and the user tries switching networks.

<img width="589" alt="Screenshot 2022-10-28 at 13 25 46" src="https://user-images.githubusercontent.com/105208209/198586852-0930935f-f065-4f5a-ae02-3298cf671655.png">
