### PR TITLE
test: only run test if env var empty or mainnet

### DIFF
--- a/frontend/automation/e2e/onboarding.test.ts
+++ b/frontend/automation/e2e/onboarding.test.ts
@@ -77,12 +77,19 @@ test.describe('onboarding', () => {
     await expect(page.getByTestId('header-title')).toHaveText(walletName2)
   })
 
-  test('import default network', async () => {
+  test('mainnet should be selctable as deafult network when envvar is mainnet or empty', async () => {
     // 0001-WALL-009 - must have Mainnet and Fairground (testnet) pre-configured (with Mainnet being the default network)
-    await page.getByTestId('network-drawer').click()
-    await page.getByTestId('network-select').click()
-    const options = await page.getByRole('menuitem').allInnerTexts()
-    expect(options).toContain('mainnet1')
+    if (
+      process.env.VITE_FEATURE_MODE === 'mainnet' ||
+      process.env.VITE_FEATURE_MODE === ''
+    ) {
+      await page.getByTestId('network-drawer').click()
+      await page.getByTestId('network-select').click()
+      const options = await page.getByRole('menuitem').allInnerTexts()
+      expect(options).toContain('mainnet1')
+    } else {
+      test.skip()
+    }
   })
 
   test('import wallet', async () => {

--- a/frontend/automation/e2e/onboarding.test.ts
+++ b/frontend/automation/e2e/onboarding.test.ts
@@ -3,7 +3,10 @@ import { expect, test } from '@playwright/test'
 
 import data from '../data/test-data.json'
 import cleanup from '../support/cleanup'
-import { waitForNetworkConnected } from '../support/helpers'
+import {
+  isMainnetConfiguration,
+  waitForNetworkConnected
+} from '../support/helpers'
 import initApp from '../support/init-app'
 
 let page: Page
@@ -79,10 +82,7 @@ test.describe('onboarding', () => {
 
   test('mainnet should be selctable as deafult network when envvar is mainnet or empty', async () => {
     // 0001-WALL-009 - must have Mainnet and Fairground (testnet) pre-configured (with Mainnet being the default network)
-    if (
-      process.env.VITE_FEATURE_MODE === 'mainnet' ||
-      process.env.VITE_FEATURE_MODE === ''
-    ) {
+    if (await isMainnetConfiguration()) {
       await page.getByTestId('network-drawer').click()
       await page.getByTestId('network-select').click()
       const options = await page.getByRole('menuitem').allInnerTexts()

--- a/frontend/automation/support/helpers.ts
+++ b/frontend/automation/support/helpers.ts
@@ -11,6 +11,14 @@ export async function getTextFromClipboard(page: Page): Promise<string> {
   return page.evaluate('navigator.clipboard.readText()')
 }
 
+export async function isMainnetConfiguration() {
+  return (
+    process.env.VITE_FEATURE_MODE === 'mainnet' ||
+    process.env.VITE_FEATURE_MODE === '' ||
+    process.env.VITE_FEATURE_MODE === undefined
+  )
+}
+
 export async function unlockWallet(
   page: Page,
   name: string,


### PR DESCRIPTION
Only run the test that checks for mainnet as default if we are running a configuration that requires mainnet to be default

@ValentinTrinque if we get this test in I believe we should test the other configurations as part of your PR, would take two seconds to write a test for that and it could go down together. Let me know what you think.