### PR TITLE
feat: increase permissions for build-binaries-workflow

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - develop
 
+permissions:
+  id-token: write
+  contents: read
+  checks: write
+
 env:
   WAILS_VERSION: v2.4.1
   NODE_VERSION: 18.12.0


### PR DESCRIPTION
Increase permissions for the dependa-bot, as per https://github.com/dorny/test-reporter/issues/149