### PR TITLE
chore: add network timeout

### DIFF
--- a/frontend/.yarnrc
+++ b/frontend/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout 1000000000


### PR DESCRIPTION
Increase network timeout for yarn install because windows is failing to build